### PR TITLE
Fix Docker Local

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -40,6 +40,6 @@ case ${SIMULATION_TYPE} in
 	LOCAL)
         mkdir -p $OUTPUT_FILE_PATH
 		cp *.cmo $OUTPUT_FILE_PATH
-		cp *.txt $OUTPUT_FILE_PATH
+		cp reports/*.txt $OUTPUT_FILE_PATH
 	;;
 esac


### PR DESCRIPTION
When I tried to run in Docker with `$SIMULATION_TYPE=LOCAL`, I'd get a warning message like this:
```cp: cannot stat '*.txt': No such file or directory```
and then there would be no outputted .txt files in the designated output directory, just a the .cmo files. 

As you can see right above the change I made, that's because the output .txt files are in the reports/ directory, so this change is to just copy those files from the proper place. 

I verified that this change fixes the issue when I build the docker image locally, but I need to propogate this change up to the docker image on docker hub so we can use it in Google Colab